### PR TITLE
update brew commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ Another method, if you have [Homebrew Cask](http://caskroom.io/) installed:
 
 ```sh
 brew update
-brew cask install quickjson
+brew install --cask quickjson
 ```
 
 To uninstall:
 
 ```sh
-brew cask uninstall quickjson
+brew uninstall --cask quickjson
 ```


### PR DESCRIPTION
brew recently disabled `brew cask install` and switch to `brew install --cask`. 

This PR updates the readme to use the new command.

You can see others talking about the change here: https://github.com/ansible-collections/community.general/issues/1524